### PR TITLE
Inittialize feedstock

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,0 +1,6 @@
+channels:
+  melody_org: flask-update
+build_parameters:
+  - "--suppress-variables"
+  - "--error-overlinking"
+  - "--error-overdepending"

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,6 +1,0 @@
-channels:
-  melody_org: flask-update
-build_parameters:
-  - "--suppress-variables"
-  - "--error-overlinking"
-  - "--error-overdepending"

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -36,6 +36,9 @@ test:
 about:
   home: https://airflow.apache.org/
   summary: Provider for Apache Airflow. Implements apache-airflow-providers-common-sql package
+  description: |
+    This is a provider package for common.sql provider.
+    All classes for this provider package are in airflow.providers.common.sql python package.
   license: Apache-2.0
   license_file:
     - LICENSE

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -19,6 +19,7 @@ requirements:
     - python
     - setuptools
     - pip
+    - wheel
   run:
     - python
     - sqlparse >=0.4.2

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -44,8 +44,8 @@ about:
     - LICENSE
     - NOTICE
   license_family: Apache
-  doc_url: https://airflow.apache.org/docs/apache-airflow-providers-common-sql/stable/index.html
-  dev_url: https://github.com/apache/airflow/
+  doc_url: https://airflow.apache.org/docs/apache-airflow-providers-common-sql/
+  dev_url: https://github.com/apache/airflow/tree/main/airflow/providers/common/sql/
 
 extra:
   recipe-maintainers:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,17 +10,17 @@ source:
   sha256: 510cd732014248514196727e649ed2c70960f3c4a73b62b4c21a2a58bd92b445
 
 build:
-  noarch: python
+  skipt: true  # [py<37]
   script: {{ PYTHON }} -m pip install . -vv
   number: 0
 
 requirements:
   host:
-    - python >=3.7
+    - python
     - setuptools
     - pip
   run:
-    - python >=3.7
+    - python
     - sqlparse >=0.4.2
 
 test:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,7 +10,7 @@ source:
   sha256: 510cd732014248514196727e649ed2c70960f3c4a73b62b4c21a2a58bd92b445
 
 build:
-  skipt: true  # [py<37]
+  skip: true  # [py<37]
   script: {{ PYTHON }} -m pip install . -vv
   number: 0
 


### PR DESCRIPTION
Build package for apache-airflow-providers-common-sql-feedstock

[airflow 2.4.3](https://github.com/AnacondaRecipes/airflow-feedstock/pull/13) <-- `apache-airflow-providers-common-sql`

Jira ticket: [PKG-574](https://anaconda.atlassian.net/browse/PKG-574)

Home: https://airflow.apache.org/
Documentation: https://airflow.apache.org/docs/apache-airflow-providers-common-sql/stable/index.html
Development: https://github.com/apache/airflow/